### PR TITLE
Added grunt banner plugin for copyright banner and restructured License and Copyright related files as per the Fluid Community's conventions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,34 @@
+<!--
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/raw/master/AUTHORS.md.
+
+Licensed under the BSD 3-Clause License. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the BSD 3-Clause License at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
+-->
+
+# Authors
+
+## Copyright Holders
+
+This is the list of Gamepad Navigator copyright holders. It does not list all individual contributors because some have
+assigned copyright to an institution or made only minor changes. Please see the version control system's revision
+history for details on contributions.
+
+Copyright (c) 2020
+
+- Divyanshu Mahajan
+- Tony Atkins
+- Fluid Project
+
+## Contributors
+
+Individual contributions can be viewed on the
+[Contributors](https://github.com/fluid-lab/gamepad-navigator/graphs/contributors) page, or through the version control
+system's revision history.
+
+_**Note**: Individual authors may not hold copyright. See above "[Copyright Holders](#copyright-holders)" section for
+more information._

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,20 +1,60 @@
+/*
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/raw/master/AUTHORS.md.
+
+Licensed under the BSD 3-Clause License. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the BSD 3-Clause License at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
+*/
+
 /* eslint-env node */
 "use strict";
 
 module.exports = function (grunt) {
     grunt.config.init({
+        licenseBanner: grunt.file.read("templates/LICENSE-banner.txt"),
+        currentMarkdownBanner: /^(<!--)\s[\w\W]+?(-->)\s\s/m,
+        currentJsAndJson5Banner: /^\/\*\sCopyright \(c\)[\w\W]+?\s\*\/\s\s/m,
         lintAll: {
             sources: {
                 js:    ["./src/js/**/*.js", "tests/js/**/*.js", "./*.js"],
-                md:    [ "./*.md", "tests/**/*.md"],
+                md:    ["./*.md", "tests/**/*.md", "docs/*.md"],
                 json:  ["./*.json", "./.*.json", "tests/**/*.json"],
                 json5: ["./*.json5", "tests/**/*.json5"],
                 other: ["./.*"]
             }
+        },
+        usebanner: {
+            jsAndJson5: {
+                options: {
+                    position: "top",
+                    replace: "<%= currentJsAndJson5Banner %>",
+                    banner: "/*\n<%= licenseBanner %>*/\n"
+                },
+                files: {
+                    src: ["./src/js/**/*.js", "tests/js/**/*.js", "./*.js", "./*.json5", "tests/**/*.json5"]
+                }
+            },
+            markdown: {
+                options: {
+                    position: "top",
+                    replace: "<%= currentMarkdownBanner %>",
+                    banner: "<!--\n<%= licenseBanner %>-->\n"
+                },
+                files: {
+                    src: ["./*.md", "tests/**/*.md", "docs/*.md"]
+                }
+            }
         }
     });
     grunt.loadNpmTasks("gpii-grunt-lint-all");
+    grunt.loadNpmTasks("grunt-banner");
+
     grunt.registerTask("lint", "Perform all standard lint checks.", ["lint-all"]);
+    grunt.registerTask("banner", "Add copyright banner at the top of files.", ["usebanner"]);
 
     grunt.registerTask("default", ["lint"]);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,9 +15,6 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
 module.exports = function (grunt) {
     grunt.config.init({
-        licenseBanner: grunt.file.read("templates/LICENSE-banner.txt"),
-        currentMarkdownBanner: /^(<!--)\s[\w\W]+?(-->)\s\s/m,
-        currentJsAndJson5Banner: /^\/\*\sCopyright \(c\)[\w\W]+?\s\*\/\s\s/m,
         lintAll: {
             sources: {
                 js:    ["./src/js/**/*.js", "tests/js/**/*.js", "./*.js"],
@@ -30,7 +27,6 @@ module.exports = function (grunt) {
         usebanner: {
             jsAndJson5: {
                 options: {
-                    position: "top",
                     replace: "<%= currentJsAndJson5Banner %>",
                     banner: "/*\n<%= licenseBanner %>*/\n"
                 },
@@ -40,7 +36,6 @@ module.exports = function (grunt) {
             },
             markdown: {
                 options: {
-                    position: "top",
                     replace: "<%= currentMarkdownBanner %>",
                     banner: "<!--\n<%= licenseBanner %>-->\n"
                 },
@@ -48,7 +43,10 @@ module.exports = function (grunt) {
                     src: ["./*.md", "tests/**/*.md", "docs/*.md"]
                 }
             }
-        }
+        },
+        licenseBanner: grunt.file.read("templates/LICENSE-banner.txt"),
+        currentMarkdownBanner: /^(<!--)\s[\w\W]+?(-->)\s\s/m,
+        currentJsAndJson5Banner: /^\/\*\sCopyright \(c\)[\w\W]+?\s\*\/\s\s/m
     });
     grunt.loadNpmTasks("gpii-grunt-lint-all");
     grunt.loadNpmTasks("grunt-banner");

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,26 @@
 BSD 3-Clause License
 
-Copyright (c) 2020, Divyanshu Mahajan
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/AUTHORS.md
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+   disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+<!--
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/raw/master/AUTHORS.md.
+
+Licensed under the BSD 3-Clause License. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the BSD 3-Clause License at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
+-->
+
 # Gamepad Navigator
 
 Gamepads are popular devices, and a lot of work has been done to extend its usefulness to a wide variety of people.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "eslint": "7.1.0",
         "eslint-config-fluid": "1.4.0",
         "gpii-grunt-lint-all": "1.0.7",
-        "grunt": "1.1.0"
+        "grunt": "1.1.0",
+        "grunt-banner": "0.6.0"
     }
 }

--- a/templates/LICENSE-banner.txt
+++ b/templates/LICENSE-banner.txt
@@ -1,0 +1,9 @@
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/raw/master/AUTHORS.md.
+
+Licensed under the BSD 3-Clause License. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the BSD 3-Clause License at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE


### PR DESCRIPTION
I have added one template for copyright boilerplate in the `templates` directory. The current grunt banner configuration that I have set up doesn't require multiple templates (for JavaScript, JSON5, and Markdown files) as long as the content of the boilerplate is the same for different categories of files.