### PR TITLE
Updated tab navigation tests to use the same pattern in click tests

### DIFF
--- a/tests/html/tab-tests.html
+++ b/tests/html/tab-tests.html
@@ -17,6 +17,7 @@
         <script type="text/javascript" src="../../src/js/content_scripts/input-mapper.js"></script>
 
         <script type="text/javascript" src="../js/gamepad-mock.js"></script>
+        <script type="text/javascript" src="../js/test-utils.js"></script>
         <script type="text/javascript" src="../js/tab/tab-mock-utils.js"></script>
         <script type="text/javascript" src="../js/tab/tab-order-tests.js"></script>
         <script type="text/javascript" src="../js/tab/tab-button-discrete-tests.js"></script>

--- a/tests/js/tab/tab-axes-tests.js
+++ b/tests/js/tab/tab-axes-tests.js
@@ -22,26 +22,7 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
         jqUnit.module("Gamepad Navigator Axes Tab Navigation Tests", {
             setup: function () {
                 gamepad.tests.windowObject = window;
-                gamepad.tests.count = 2;
                 gamepad.tests.frequency = 50;
-
-                // To test the gamepad's initial state.
-                gamepad.tests.modelAtRest = {
-                    connected: true,
-                    axes: {},
-                    buttons: {}
-                };
-
-                // Initialize in accordance with the 18 buttons on the PS4 controller.
-                for (var buttonNumber = 0; buttonNumber < 18; buttonNumber++) {
-                    gamepad.tests.modelAtRest.buttons[buttonNumber] = 0;
-                }
-
-                // Initialize in accordance with the 4 axes on the PS4 controller.
-                for (var axesNumber = 0; axesNumber < 4; axesNumber++) {
-                    gamepad.tests.modelAtRest.axes[axesNumber] = 0;
-                }
-
                 jqUnit.expect(5);
             },
             teardown: function () {
@@ -53,23 +34,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Tab from the last element to the first in forward tabbing using axes.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.axes.forwardTab(2);
+                return gamepad.tests.utils.axes.forwardTab(2, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on the last element.
             $("#last").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#last"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#last", gamepad.tests.navigator);
 
             /**
              * Update the gamepad to tilt axes 2 in the right direction for forward tab
@@ -95,23 +68,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Tab from the first element to the last in reverse tabbing using axes.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.axes.reverseTab(2);
+                return gamepad.tests.utils.axes.reverseTab(2, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on the first element.
             $("#first").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#first"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#first", gamepad.tests.navigator);
 
             /**
              * Update the gamepad to tilt axes 2 in the left direction for reverse tab
@@ -137,23 +102,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Change the focus to one of the next elements in forward tabbing using axes.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.axes.forwardTab(2);
+                return gamepad.tests.utils.axes.forwardTab(2, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on the first element.
             $("#first").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#first"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#first", gamepad.tests.navigator);
 
             // Record the tabindex of the focused elements before polling.
             var beforePollingFocusedElementTabIndex = document.activeElement.getAttribute("tabindex");
@@ -181,23 +138,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Change the focus to one of the previous elements in reverse tabbing using axes.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.axes.reverseTab(2);
+                return gamepad.tests.utils.axes.reverseTab(2, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on some element in the middle.
             $("#fifth").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#fifth"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#fifth", gamepad.tests.navigator);
 
             // Record the tabindex of the focused element before polling.
             var beforePollingFocusedElementTabIndex = document.activeElement.getAttribute("tabindex");

--- a/tests/js/tab/tab-button-continuous-tests.js
+++ b/tests/js/tab/tab-button-continuous-tests.js
@@ -22,26 +22,7 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
         jqUnit.module("Gamepad Navigator Button (Continuous) Tab Navigation Tests", {
             setup: function () {
                 gamepad.tests.windowObject = window;
-                gamepad.tests.count = 2;
                 gamepad.tests.frequency = 50;
-
-                // To test the gamepad's initial state.
-                gamepad.tests.modelAtRest = {
-                    connected: true,
-                    axes: {},
-                    buttons: {}
-                };
-
-                // Initialize in accordance with the 18 buttons on the PS4 controller.
-                for (var buttonNumber = 0; buttonNumber < 18; buttonNumber++) {
-                    gamepad.tests.modelAtRest.buttons[buttonNumber] = 0;
-                }
-
-                // Initialize in accordance with the 4 axes on the PS4 controller.
-                for (var axesNumber = 0; axesNumber < 4; axesNumber++) {
-                    gamepad.tests.modelAtRest.axes[axesNumber] = 0;
-                }
-
                 jqUnit.expect(5);
             },
             teardown: function () {
@@ -53,23 +34,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Change the focus to one of the next elements in continuous forward tabbing using buttons.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.buttons.tab(5);
+                return gamepad.tests.utils.buttons.tab(5, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on the first element.
             $("#first").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#first"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#first", gamepad.tests.navigator);
 
             // Record the state of focused elements before polling.
             var beforePollingFocusedElementTabIndex = document.activeElement.getAttribute("tabindex");
@@ -97,23 +70,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Change the focus to one of the previous elements in continuous reverse tabbing using buttons.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.buttons.tab(4);
+                return gamepad.tests.utils.buttons.tab(4, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on some element in the middle.
             $("#fifth").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#fifth"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#fifth", gamepad.tests.navigator);
 
             // Record the state of focused elements before polling.
             var beforePollingFocusedElementTabIndex = document.activeElement.getAttribute("tabindex");

--- a/tests/js/tab/tab-button-discrete-tests.js
+++ b/tests/js/tab/tab-button-discrete-tests.js
@@ -22,26 +22,7 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
         jqUnit.module("Gamepad Navigator Button (Discrete) Tab Navigation Tests", {
             setup: function () {
                 gamepad.tests.windowObject = window;
-                gamepad.tests.count = 2;
                 gamepad.tests.frequency = 50;
-
-                // To test the gamepad's initial state.
-                gamepad.tests.modelAtRest = {
-                    connected: true,
-                    axes: {},
-                    buttons: {}
-                };
-
-                // Initialize in accordance with the 18 buttons on the PS4 controller.
-                for (var buttonNumber = 0; buttonNumber < 18; buttonNumber++) {
-                    gamepad.tests.modelAtRest.buttons[buttonNumber] = 0;
-                }
-
-                // Initialize in accordance with the 4 axes on the PS4 controller.
-                for (var axesNumber = 0; axesNumber < 4; axesNumber++) {
-                    gamepad.tests.modelAtRest.axes[axesNumber] = 0;
-                }
-
                 jqUnit.expect(5);
             },
             teardown: function () {
@@ -53,23 +34,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Tab from the last element to the first in discrete forward tabbing using buttons.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.buttons.tab(5);
+                return gamepad.tests.utils.buttons.tab(5, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on the last element.
             $("#last").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#last"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#last", gamepad.tests.navigator);
 
             /**
              * Update the gamepad to press button 5 (right bumper) for forward tab
@@ -95,23 +68,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Tab from the first element to the last in discrete reverse tabbing using buttons.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.buttons.tab(4);
+                return gamepad.tests.utils.buttons.tab(4, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on the first element.
             $("#first").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#first"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#first", gamepad.tests.navigator);
 
             /**
              * Update the gamepad to press button 4 (left bumper) for reverse tab
@@ -137,23 +102,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Change the focus to the next element in discrete forward tabbing using buttons.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.buttons.tab(5);
+                return gamepad.tests.utils.buttons.tab(5, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on the first element.
             $("#first").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#first"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#first", gamepad.tests.navigator);
 
             /**
              * Update the gamepad to press button 5 (right bumper) for forward tab
@@ -174,23 +131,15 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
         jqUnit.asyncTest("Change the focus to the previous element in discrete reverse tabbing using buttons.", function () {
             gamepad.tests.windowObject.navigator.getGamepads = function () {
-                return gamepad.tests.utils.buttons.tab(4);
+                return gamepad.tests.utils.buttons.tab(4, gamepad.tests.navigator);
             };
 
             // Set initial conditions i.e., focus on some element in the middle.
             $("#fifth").focus();
 
             // Confirm that the instance of the gamepad navigator is created.
-            gamepad.tests.navigator = gamepad.inputMapper({
-                windowObject: gamepad.tests.windowObject,
-                frequency: gamepad.tests.frequency
-            });
-            jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(gamepad.tests.navigator));
-
-            // Check the state of gamepad inputs and webpage after polling.
-            gamepad.tests.navigator.pollGamepads();
-            jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", gamepad.tests.modelAtRest, gamepad.tests.navigator.model);
-            jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector("#fifth"), document.activeElement);
+            gamepad.tests.navigator = gamepad.tests.inputMapperForTabTests({ frequency: gamepad.tests.frequency });
+            gamepad.tests.utils.initialClickTestChecks("#fifth", gamepad.tests.navigator);
 
             /**
              * Update the gamepad to press button 4 (right bumper) for reverse tab

--- a/tests/js/tab/tab-mock-utils.js
+++ b/tests/js/tab/tab-mock-utils.js
@@ -10,7 +10,7 @@ You may obtain a copy of the BSD 3-Clause License at
 https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 */
 
-/* global gamepad */
+/* global gamepad, jqUnit */
 
 (function (fluid) {
     "use strict";
@@ -18,21 +18,31 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
     fluid.registerNamespace("gamepad.tests.utils.buttons");
     fluid.registerNamespace("gamepad.tests.utils.axes");
 
+    // Custom gamepad navigator component grade for tab navigation tests.
+    fluid.defaults("gamepad.tests.inputMapperForTabTests", {
+        gradeNames: ["gamepad.inputMapper"],
+        windowObject: gamepad.tests.windowObject,
+        members: { count: 2 }
+    });
+
     /**
      *
      * Generates a mock for one-time tab navigation in button tests.
      *
      * @param {Object} inputButton - The index number of the button.
      *
+     * @param {Object} testNavigatorInstance - The instance of the gamepad navigator's
+     *                                         custom inputMapper component under test.
+     *
      * @return {Array} - The mock of the gamepad.
      *
      */
-    gamepad.tests.utils.buttons.tab = function (inputButton) {
+    gamepad.tests.utils.buttons.tab = function (inputButton, testNavigatorInstance) {
         var gamepadMock = null,
             inputSpec = { buttons: {} };
 
         // Initial count is set to 2 in all cases.
-        if (gamepad.tests.count === 1) {
+        if (testNavigatorInstance.count === 1) {
             inputSpec.buttons[inputButton] = 1;
         }
 
@@ -40,7 +50,7 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
         gamepadMock = gamepad.tests.utils.generateGamepadMock(inputSpec);
 
         // Reduce the count on every call.
-        gamepad.tests.count--;
+        testNavigatorInstance.count--;
         return gamepadMock;
     };
 
@@ -50,15 +60,18 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
      *
      * @param {Object} inputAxes - The index number of the axes.
      *
+     * @param {Object} testNavigatorInstance - The instance of the gamepad navigator's
+     *                                         custom inputMapper component under test.
+     *
      * @return {Array} - The mock of the gamepad.
      *
      */
-    gamepad.tests.utils.axes.forwardTab = function (inputAxes) {
+    gamepad.tests.utils.axes.forwardTab = function (inputAxes, testNavigatorInstance) {
         var gamepadMock = null,
             inputSpec = { axes: {} };
 
         // Initial count is set to 2 in all cases.
-        if (gamepad.tests.count === 1) {
+        if (testNavigatorInstance.count === 1) {
             inputSpec.axes[inputAxes] = 1;
         }
 
@@ -66,7 +79,7 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
         gamepadMock = gamepad.tests.utils.generateGamepadMock(inputSpec);
 
         // Reduce the count on every call.
-        gamepad.tests.count--;
+        testNavigatorInstance.count--;
         return gamepadMock;
     };
 
@@ -76,15 +89,18 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
      *
      * @param {Object} inputAxes - The index number of the axes.
      *
+     * @param {Object} testNavigatorInstance - The instance of the gamepad navigator's
+     *                                         custom inputMapper component under test.
+     *
      * @return {Array} - The mock of the gamepad.
      *
      */
-    gamepad.tests.utils.axes.reverseTab = function (inputAxes) {
+    gamepad.tests.utils.axes.reverseTab = function (inputAxes, testNavigatorInstance) {
         var gamepadMock = null,
             inputSpec = { axes: {} };
 
         // Initial count is set to 2 in all cases.
-        if (gamepad.tests.count === 1) {
+        if (testNavigatorInstance.count === 1) {
             inputSpec.axes[inputAxes] = -1;
         }
 
@@ -92,7 +108,28 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
         gamepadMock = gamepad.tests.utils.generateGamepadMock(inputSpec);
 
         // Reduce the count on every call.
-        gamepad.tests.count--;
+        testNavigatorInstance.count--;
         return gamepadMock;
+    };
+
+    /**
+     *
+     * A helper function for the initial checks for tab navigation tests after first
+     * polling cycle.
+     *
+     * @param {Object} elementQuery - The DOM element to be used for testing.
+     *
+     * @param {Object} testNavigatorInstance - The instance of the gamepad navigator's
+     *                                         inputMapper component under test.
+     *
+     */
+    gamepad.tests.utils.initialClickTestChecks = function (elementQuery, testNavigatorInstance) {
+        jqUnit.assertTrue("The Gamepad Navigator should be instantiated.", fluid.isComponent(testNavigatorInstance));
+        var modelAtRest = gamepad.tests.utils.initializeModelAtRest();
+
+        // Check the state of gamepad inputs and webpage after polling.
+        gamepad.tests.navigator.pollGamepads();
+        jqUnit.assertLeftHand("The gamepad should be connected with no buttons/axes disturbed initially.", modelAtRest, testNavigatorInstance.model);
+        jqUnit.assertEquals("The focus should not be changed after polling.", document.querySelector(elementQuery), document.activeElement);
     };
 })(fluid);


### PR DESCRIPTION
I've changed those usage patterns in the tab navigation tests which we discussed for change in the click tests pull request (#16). This will help to maintain uniformity and readability to other developers in the future.