### PR TITLE
Added gamepad.navigator documentation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
                     banner: "<!--\n<%= usebanner.options.licenseBanner %>-->\n"
                 },
                 files: {
-                    src: ["./*.md", "tests/**/*.md", "docs/*.md"]
+                    src: ["./*.md", "tests/**/*.md", "docs/**/*.md"]
                 }
             }
         },

--- a/docs/CANDIDATE_TECHNOLOGIES.md
+++ b/docs/CANDIDATE_TECHNOLOGIES.md
@@ -1,3 +1,15 @@
+<!--
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/raw/master/AUTHORS.md.
+
+Licensed under the BSD 3-Clause License. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the BSD 3-Clause License at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
+-->
+
 # Candidate Technologies for the Gamepad Navigator
 
 ## Table of Contents

--- a/docs/components/navigator.md
+++ b/docs/components/navigator.md
@@ -1,0 +1,115 @@
+<!--
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/raw/master/AUTHORS.md.
+
+Licensed under the BSD 3-Clause License. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the BSD 3-Clause License at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
+-->
+
+# gamepad.navigator
+
+This component listens to the `gamepadconnected` and `gamepaddisconnected` events in the browser. When at least one
+gamepad is connected, it reads inputs from them at a particular frequency and stores those input values in the
+component's model data. The component stops reading these inputs when the last gamepad is disconnected.
+
+## Using this grade
+
+This grade can work without passing any option to it. An instance of the `navigator` does not require any options to be
+passed and can listen to the gamepad events and read the gamepad inputs. To use it, we can create an instance of the
+component or use it as a grade another component:
+
+``` javascript
+// Either create an instance of the navigator.
+var navigatorInstanceOne = gamepad.navigator();
+
+// Otherwise create a custom component using the navigator grade.
+fluid.defaults("my.navigator.grade", {
+    gradeNames: ["gamepad.navigator"]
+};
+var navigatorInstanceTwo = my.navigator.grade();
+```
+
+## Component Options
+
+The following component configuration options are supported:
+
+| Option | Type | Default Value | Description |
+| :---: | :---: | :---: | :--- |
+| `windowObject` | `{Object}` | `window` | The global window object from which the navigator derives various methods to read gamepad inputs and attach listeners to it for various gamepad events. |
+| `frequency` | `{Integer}` | 50 | The frequency (in ms) at which the navigator will read gamepad inputs. |
+
+These options can be provided to the component in the following ways:
+
+```javascript
+// Either pass the options inside the object as an argument while creating an instance of the navigator.
+var navigatorInstanceOne = gamepad.navigator({
+    windowObject: myCustomWindowObject,
+    frequency: 100
+});
+
+// Otherwise pass it as default options in a custom component using the navigator grade.
+fluid.defaults("my.navigator.grade", {
+    gradeNames: ["gamepad.navigator"],
+    windowObject: myCustomWindowObject,
+    frequency: 100
+};
+var navigatorInstanceTwo = my.navigator.grade();
+```
+
+Though the `windowObject` is a configurable option, it should have all the properties and methods that the navigator
+uses. Otherwise, the navigator won't work and will throw errors. You can also use a mutated `window` object and pass it
+into the component if you want to achieve a different behavior. That'll be less likely to throw errors and is the same
+pattern used in our tests.
+
+## Invokers
+
+### `{navigator}.attachListener(that)`
+
+- `that {Object}` The gamepad navigator component.
+- Returns: Nothing.
+
+It attaches event listeners to the `windowObject` for the `gamepadconnected` and `gamepaddisconnected` events. When
+these events are fired, the navigator fires its native `onGamepadConnected` or `onGamepadDisconnected` events,
+depending upon the former event. These events have listeners attached to it, which start reading the gamepad inputs or
+stop reading it further.
+
+### `{navigator}.onConnected(that)`
+
+- `that {Object}` The gamepad navigator component.
+- Returns: Nothing.
+
+It is the listener for the gamepad navigator component's event `onGamepadConnected`. When it is called, it initiates
+the gamepad polling invoker [`{navigator}.pollGamepads`](#navigatorpollgamepadsthat) to be called at the same frequency
+as specified in the component's configurable option `frequency`. The interval ID is stored in the component's member
+`connectivityIntervalReference` for reference in other invokers and listeners present in the component.
+
+### `{navigator}.pollGamepads(that)`
+
+- `that {Object}` The gamepad navigator component.
+- Returns: Nothing.
+
+It is called in intervals for reading the gamepad inputs and updating the navigator component's model with those
+values. The inputs are read from all the connected gamepads and then combine them to provide the co-pilot mode
+experience.
+
+### `{navigator}.onDisconnected(that)`
+
+- `that {Object}` The gamepad navigator component.
+- Returns: Nothing.
+
+It is the listener for the gamepad navigator component's event `onGamepadDisconnected`. When it is called, it stops
+the polling function interval loop and then checks whether any gamepad is still connected. If any gamepad is found
+connected, it will fire the `onGamepadConnected` event so that the navigator continues to read gamepad inputs.
+Otherwise, the navigator will restore the component's model to its initial state (when no gamepad was connected).
+
+### `{navigator}.clearConnectivityInterval(connectivityIntervalReference)`
+
+- `connectivityIntervalReference {Integer}` The ID of the interval reading the gamepad inputs.
+- Returns: Nothing.
+
+It is used as a listener for the navigator component's `onDestroy` event and will clear the polling function interval
+loop when called.

--- a/docs/components/navigator.md
+++ b/docs/components/navigator.md
@@ -10,7 +10,7 @@ You may obtain a copy of the BSD 3-Clause License at
 https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 -->
 
-# gamepad.navigator
+# `gamepad.navigator`
 
 This component listens to the `gamepadconnected` and `gamepaddisconnected` events in the browser. When at least one
 gamepad is connected, it reads inputs from them at a particular frequency and stores those input values in the
@@ -18,9 +18,8 @@ component's model data. The component stops reading these inputs when the last g
 
 ## Using this grade
 
-This grade can work without passing any option to it. An instance of the `navigator` does not require any options to be
-passed and can listen to the gamepad events and read the gamepad inputs. To use it, we can create an instance of the
-component or use it as a grade another component:
+You can change the configuration options by either extending the component or by passing your own options. If no
+options are passed, the defaults are used.
 
 ``` javascript
 // Either create an instance of the navigator.
@@ -61,9 +60,9 @@ var navigatorInstanceTwo = my.navigator.grade();
 ```
 
 Though the `windowObject` is a configurable option, it should have all the properties and methods that the navigator
-uses. Otherwise, the navigator won't work and will throw errors. You can also use a mutated `window` object and pass it
-into the component if you want to achieve a different behavior. That'll be less likely to throw errors and is the same
-pattern used in our tests.
+uses. Otherwise, the navigator won't work and will throw errors. You can also use a modified `window` object, such as
+the gamepad mocks used in this package's tests, and pass it into the component if you want to achieve a different
+behavior. That'll be less likely to throw errors.
 
 ## Invokers
 
@@ -72,19 +71,19 @@ pattern used in our tests.
 - `that {Object}` The gamepad navigator component.
 - Returns: Nothing.
 
-It attaches event listeners to the `windowObject` for the `gamepadconnected` and `gamepaddisconnected` events. When
-these events are fired, the navigator fires its native `onGamepadConnected` or `onGamepadDisconnected` events,
-depending upon the former event. These events have listeners attached to it, which start reading the gamepad inputs or
-stop reading it further.
+Attaches event listeners to the `windowObject` for the `gamepadconnected` and `gamepaddisconnected` events. When these
+events are fired, the navigator fires its native `onGamepadConnected` or `onGamepadDisconnected` events, depending upon
+the former event. These events have listeners attached to it, which start reading the gamepad inputs or stop reading it
+further.
 
 ### `{navigator}.onConnected(that)`
 
 - `that {Object}` The gamepad navigator component.
 - Returns: Nothing.
 
-It is the listener for the gamepad navigator component's event `onGamepadConnected`. When it is called, it initiates
-the gamepad polling invoker [`{navigator}.pollGamepads`](#navigatorpollgamepadsthat) to be called at the same frequency
-as specified in the component's configurable option `frequency`. The interval ID is stored in the component's member
+Listens for the gamepad navigator component's event `onGamepadConnected`. When it is called, it initiates the gamepad
+polling invoker [`{navigator}.pollGamepads`](#navigatorpollgamepadsthat) to be called at the same frequency as
+specified in the component's configurable option `frequency`. The interval ID is stored in the component's member
 `connectivityIntervalReference` for reference in other invokers and listeners present in the component.
 
 ### `{navigator}.pollGamepads(that)`
@@ -92,24 +91,22 @@ as specified in the component's configurable option `frequency`. The interval ID
 - `that {Object}` The gamepad navigator component.
 - Returns: Nothing.
 
-It is called in intervals for reading the gamepad inputs and updating the navigator component's model with those
-values. The inputs are read from all the connected gamepads and then combine them to provide the co-pilot mode
-experience.
+Called periodically to read the gamepad inputs and to update the navigator component's model with those values. The
+inputs are read from all the connected gamepads and then combine them to provide the co-pilot mode experience.
 
 ### `{navigator}.onDisconnected(that)`
 
 - `that {Object}` The gamepad navigator component.
 - Returns: Nothing.
 
-It is the listener for the gamepad navigator component's event `onGamepadDisconnected`. When it is called, it stops
-the polling function interval loop and then checks whether any gamepad is still connected. If any gamepad is found
-connected, it will fire the `onGamepadConnected` event so that the navigator continues to read gamepad inputs.
-Otherwise, the navigator will restore the component's model to its initial state (when no gamepad was connected).
+Listens for the gamepad navigator component's event `onGamepadDisconnected`. When it is called, it stops the polling
+function interval loop and then checks whether any gamepad is still connected. If any gamepad is found connected, it
+will fire the `onGamepadConnected` event so that the navigator continues to read gamepad inputs. Otherwise, the
+navigator will restore the component's model to its initial state (when no gamepad was connected).
 
 ### `{navigator}.clearConnectivityInterval(connectivityIntervalReference)`
 
 - `connectivityIntervalReference {Integer}` The ID of the interval reading the gamepad inputs.
 - Returns: Nothing.
 
-It is used as a listener for the navigator component's `onDestroy` event and will clear the polling function interval
-loop when called.
+Listens for the navigator component's `onDestroy` event and will clear the polling function interval loop when called.


### PR DESCRIPTION
The documentation follows the same pattern as used in [Fluid Express Docs](https://github.com/fluid-project/fluid-express/tree/master/docs).