### PR TITLE
Added documentation for configMaps grade

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
         lintAll: {
             sources: {
                 js:    ["./src/js/**/*.js", "tests/js/**/*.js", "./*.js"],
-                md:    ["./*.md", "tests/**/*.md", "docs/*.md"],
+                md:    ["./*.md", "tests/**/*.md", "docs/**/*.md"],
                 json:  ["./*.json", "./.*.json", "tests/**/*.json"],
                 json5: ["./*.json5", "tests/**/*.json5"],
                 other: ["./.*"]

--- a/docs/components/configMaps.md
+++ b/docs/components/configMaps.md
@@ -12,7 +12,13 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
 # `gamepad.configMaps`
 
-// TODO: Add links referencing the "mix in" components' documentation.
+<!--
+TODO: Add links referencing the "mix in" components' documentation. 
+
+TODO: Add documentation for supported actions.
+Refer:
+https://github.com/fluid-lab/gamepad-navigator/issues/50
+-->
 
 This grade provides the configuration maps for the gamepad. It is used in the `gamepad.configurationPanel` and
 `gamepad.inputMapper.base` grades that provide the actual functionality according to the configuration.

--- a/docs/components/configMaps.md
+++ b/docs/components/configMaps.md
@@ -1,0 +1,146 @@
+<!--
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/raw/master/AUTHORS.md.
+
+Licensed under the BSD 3-Clause License. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the BSD 3-Clause License at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
+-->
+
+# `gamepad.configMaps`
+
+This grade provides the configuration maps for the gamepad in the form of component's model data.
+
+## Using this grade
+
+This can be used by passing it to the component's `gradeNames` option.
+
+``` javascript
+fluid.defaults("my.configMaps.grade", {
+    gradeNames: ["gamepad.configMaps"]
+};
+
+var configMapsInstance = my.configMaps.grade();
+```
+
+## Component Options
+
+This grade doesn't use or provide any configuration options. It only uses the model data to provide gamepad configuration
+maps to other components. However, the grade can be extended to provide custom configuration options.
+
+## Model Structure
+
+The grade stores the model data in the following format:
+
+``` javascript
+model: {
+    map: {
+        buttons: {
+            "0": {
+                defaultAction: "previousPageInHistory",
+                currentAction: null,
+                speedFactor: 1,
+                background: false
+            },
+            // The buttons below use same format as above but have different values for configuration options (keys).
+            "1": {...},
+            "2": {...},
+            "3": {...},
+            "4": {...},
+            "5": {...},
+            "6": {...},
+            "7": {...},
+            "8": {...},
+            "9": {...},
+            "10": {...},
+            "11": {...},
+            "12": {...},
+            "13": {...},
+            "14": {...},
+            "15": {...},
+            // The buttons below are reserved for special functionality so they cannot be configured.
+            "16": null,
+            "17": null
+        },
+        axes: {
+            "0": {
+                defaultAction: "scrollHorizontally",
+                currentAction: null,
+                speedFactor: 1,
+                invert: false
+            },
+            // The axes below use the same format as above but have different values for configuration options (keys).
+            "1": {...},
+            "2": {...},
+            "3": {...}
+        }
+    },
+    // Stores all the common configuration options for the gamepad actions.
+    commonConfiguration: {
+        homepageURL: "https://www.google.com/"
+    }
+}
+```
+
+The first 16 buttons and all the axes are configurable. The configuration options used in their model data are explained
+below:
+
+| Option | Supported Input | Description |
+| :---: | :---: | :--- |
+| `defaultAction` | `buttons` and `axes` | The default action triggered with the particular gamepad input if the `currentAction` is not provided. |
+| `currentAction` | `buttons` and `axes` | The action triggered with the particular gamepad input. It takes precedence over the `defaultAction` and is `null` by default. However, this can be specified when the component is created. |
+| `speedFactor` | `buttons` and `axes` | The speed with which the given action should be executed. It is only applicable if the action is continuous and hence supports only a few actions. |
+| `background` | `buttons` | Specifies whether the new tab or window should be opened in background and is applicable for those two actions only. |
+| `invert` | `axes` | Supported only for actions provided to `axes` and specifies whether the direction of the action should be inverted. |
+
+The option `homepageURL` inside `commonConfiguration` option specifies the URL of the webpage that should be loaded when
+the new tab or window is opened using the gamepad.
+
+Values of the above model options can be modified by using Infusion's
+[changeApplier API](https://docs.fluidproject.org/infusion/development/ChangeApplierAPI.html) or by passing custom
+options while creating an instance.
+
+``` javascript
+fluid.defaults("my.configMaps.grade", {
+    gradeNames: ["gamepad.configMaps"]
+};
+
+// Pass new maps configuration as options.
+var configMapsInstanceOne = my.configMaps.grade({
+    model: {
+        map: {
+            buttons: {
+                "0": {
+                    currentAction: "openNewTab",
+                    background: true
+                },
+                "1": {
+                    currentAction: "forwardTab",
+                    speedFactor: 2
+                }
+            },
+            axes: {
+                "0": {
+                    currentAction: "scrollVertically",
+                    speedFactor: 2.5,
+                    invert: true
+                }
+            }
+        },
+        commonConfiguration: {
+            homepageURL: "https://www.github.com/"
+        }
+    }
+});
+
+// Modify maps using the changeApplier API.
+var configMapsInstanceOne = my.configMaps.grade();
+configMapsInstanceOne.applier.change("commonConfiguration.homepageURL", "https://www.github.com/");
+```
+
+## Invokers
+
+This grade doesn't provide any invoker methods.

--- a/docs/components/configMaps.md
+++ b/docs/components/configMaps.md
@@ -12,30 +12,38 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
 # `gamepad.configMaps`
 
-This grade provides the configuration maps for the gamepad in the form of component's model data.
+// TODO: Add links referencing the "mix in" components' documentation.
+
+This grade provides the configuration maps for the gamepad. It is used in the `gamepad.configurationPanel` and
+`gamepad.inputMapper.base` grades that provide the actual functionality according to the configuration.
 
 ## Using this grade
 
 This can be used by passing it to the component's `gradeNames` option.
 
 ``` javascript
-fluid.defaults("my.configMaps.grade", {
-    gradeNames: ["gamepad.configMaps"]
-};
+fluid.defaults("my.inputMapperBase.grade", {
+    gradeNames: ["gamepad.configMaps", "gamepad.navigator"]
+});
 
-var configMapsInstance = my.configMaps.grade();
+var inputMapperBaseInstance = my.inputMapperBase.grade();
 ```
 
 ## Component Options
 
-This grade doesn't use or provide any configuration options. It only uses the model data to provide gamepad configuration
-maps to other components. However, the grade can be extended to provide custom configuration options.
+All the configuration options for this component are also model variables. It uses the model data to provide gamepad
+configuration maps to other components. However, the grade can be extended to provide custom configuration options.
+
+| Model Variable | Description |
+| :---: | :--- |
+| `model.commonConfiguration.homepageURL` | The URL of the webpage to be loaded when a new tab or window is opened using the gamepad. Its default value is `https://www.google.com/` |
+| `model.map` | It provides the action configuration for each gamepad input and other associated properties. See below for more details. |
 
 ## Model Structure
 
 The grade stores the model data in the following format:
 
-``` javascript
+``` snippet
 model: {
     map: {
         buttons: {
@@ -93,20 +101,17 @@ below:
 | `defaultAction` | `buttons` and `axes` | The default action triggered with the particular gamepad input if the `currentAction` is not provided. |
 | `currentAction` | `buttons` and `axes` | The action triggered with the particular gamepad input. It takes precedence over the `defaultAction` and is `null` by default. However, this can be specified when the component is created. |
 | `speedFactor` | `buttons` and `axes` | The speed with which the given action should be executed. It is only applicable if the action is continuous and hence supports only a few actions. |
-| `background` | `buttons` | Specifies whether the new tab or window should be opened in background and is applicable for those two actions only. |
+| `background` | `buttons` | Specifies whether a new tab or window should be opened in background and is applicable for those two actions only. |
 | `invert` | `axes` | Supported only for actions provided to `axes` and specifies whether the direction of the action should be inverted. |
 
-The option `homepageURL` inside `commonConfiguration` option specifies the URL of the webpage that should be loaded when
-the new tab or window is opened using the gamepad.
-
-Values of the above model options can be modified by using Infusion's
+The above model options can be modified by using Infusion's
 [changeApplier API](https://docs.fluidproject.org/infusion/development/ChangeApplierAPI.html) or by passing custom
 options while creating an instance.
 
 ``` javascript
 fluid.defaults("my.configMaps.grade", {
     gradeNames: ["gamepad.configMaps"]
-};
+});
 
 // Pass new maps configuration as options.
 var configMapsInstanceOne = my.configMaps.grade({
@@ -137,10 +142,10 @@ var configMapsInstanceOne = my.configMaps.grade({
 });
 
 // Modify maps using the changeApplier API.
-var configMapsInstanceOne = my.configMaps.grade();
-configMapsInstanceOne.applier.change("commonConfiguration.homepageURL", "https://www.github.com/");
+var configMapsInstanceTwo = my.configMaps.grade();
+configMapsInstanceTwo.applier.change("commonConfiguration.homepageURL", "https://www.github.com/");
 ```
 
 ## Invokers
 
-This grade doesn't provide any invoker methods.
+This grade doesn't provide any invokers.

--- a/docs/components/navigator.md
+++ b/docs/components/navigator.md
@@ -28,7 +28,7 @@ var navigatorInstanceOne = gamepad.navigator();
 // Otherwise create a custom component using the navigator grade.
 fluid.defaults("my.navigator.grade", {
     gradeNames: ["gamepad.navigator"]
-};
+});
 var navigatorInstanceTwo = my.navigator.grade();
 ```
 
@@ -55,7 +55,7 @@ fluid.defaults("my.navigator.grade", {
     gradeNames: ["gamepad.navigator"],
     windowObject: myCustomWindowObject,
     frequency: 100
-};
+});
 var navigatorInstanceTwo = my.navigator.grade();
 ```
 


### PR DESCRIPTION
This addresses the documentation for the `configMaps` grade used in the `configurationPanel` and the `inputMapper` components.