### PR TITLE
Added documentation for inputMapper component and updated visibilityChangeTracker to pass custom configuration options

### DIFF
--- a/docs/components/inputMapper.base.md
+++ b/docs/components/inputMapper.base.md
@@ -12,13 +12,11 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
 # `gamepad.inputMapper.base`
 
-<!-- TODO: Add links to the inputMapper component's documentation -->
-
 This component transforms the gamepad inputs into actions. It is derived from the combination of two grades - the
 [`navigator`](navigator.md) grade, which reads and stores the gamepad inputs in the form of model data, and the
 [`configMaps`](configMaps.md) grade, which provides a configuration map for the gamepad inputs. The navigation features
-available with this component are limited to **intra-web page navigation** features. (Use the `inputMapper` component
-for **inter-web page navigation** features)
+available with this component are limited to **intra-web page navigation** features. (Use the
+[`inputMapper`](inputMapper.md) component for **inter-web page navigation** features)
 
 ## Using this grade
 

--- a/docs/components/inputMapper.md
+++ b/docs/components/inputMapper.md
@@ -1,0 +1,216 @@
+<!--
+Copyright (c) 2020 The Gamepad Navigator Authors
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-lab/gamepad-navigator/raw/master/AUTHORS.md.
+
+Licensed under the BSD 3-Clause License. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the BSD 3-Clause License at
+https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
+-->
+
+# `gamepad.inputMapper`
+
+<!-- TODO: Add links to the messageListener component's documentation -->
+
+This component extends the [`inputMapper.base`](inputMapper.base.md) grade to provide **inter-web page navigation**
+features. It should be used with the `messageListener` component as the navigation-producing invokers rely on background
+scripts to work correctly.
+
+## Using this grade
+
+The component can be used by creating its instance. However, you might face issues as multiple tabs will read gamepad
+inputs at the same time. To avoid those issues, you should use `gamepad.visibilityChangeTracker` in combination with
+`gamepad.inputMapperManager`.
+
+``` javascript
+gamepad.visibilityChangeTracker(gamepad.inputMapperManager);
+```
+
+`gamepad.visibilityChangeTracker` determines whether a browser tab is **visible** or **hidden**. It then passes the
+state of the tab as an argument to the `gamepad.inputMapperManager`, which creates and destroys the instance of
+`gamepad.inputMapper` accordingly.
+
+## Component Options
+
+This component supports the same [configuration options](inputMapper.base.md#component-options) provided by the
+[`inputMapper.base`](inputMapper.base.md) component. You can provide custom configuration options to the component as
+shown in the following example.
+
+``` javascript
+gamepad.visibilityChangeTracker(gamepad.inputMapperManager, {
+    cutoffValue: 0.50,
+    scrollInputMultiplier: 60,
+    model: {
+        map: {
+            buttons: {
+                "0": {
+                    currentAction: "scrollDown",
+                    speedFactor: 2.2
+                }
+            }
+        }
+    }
+});
+```
+
+## Non-navigation Invokers
+
+### `{inputMapper}.restoreFocus()`
+
+- Returns: Nothing.
+
+Restores the focus on the last focused element after the state of browser tab is changed from **hidden** to **visible**
+or after the web page is reloaded due to refreshing or history navigation.
+
+### `{inputMapper}.updateControls()`
+
+- Returns: Nothing.
+
+Updates the gamepad configuration saved by the user.
+
+## Navigation Invokers
+
+### `{inputMapper}.goToPreviousTab(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to switch to the previous browser
+tab using buttons and triggers. If the active tab is the first tab in the list, it will switch to the last tab.
+
+### `{inputMapper}.goToNextTab(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to switch to the next browser tab
+using buttons and triggers. If the active tab is the last tab in the list, it will switch to the first tab.
+
+### `{inputMapper}.closeCurrentTab(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to close the current browser tab
+using buttons and triggers.
+
+### `{inputMapper}.openNewTab(value, oldValue, background, homepageURL)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- `background {Boolean}` Whether a new browser tab should open in background.
+- `homepageURL {String}` URL that a new browser tab should load when opened.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to open a new browser tab
+using buttons and triggers.
+
+### `{inputMapper}.openNewWindow(value, oldValue, background, homepageURL)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- `background {Boolean}` Whether a new browser window should open in background.
+- `homepageURL {String}` URL that a new browser window should load when opened.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to open a new browser window
+using buttons and triggers.
+
+### `{inputMapper}.closeCurrentWindow(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to close the current browser window
+using buttons and triggers.
+
+### `{inputMapper}.goToPreviousWindow(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to switch to the previous browser
+window using buttons and triggers.
+
+### `{inputMapper}.goToNextWindow(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to switch to the next browser
+window using buttons and triggers.
+
+### `{inputMapper}.zoomIn(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to zoom in on the current web page
+using buttons and triggers.
+
+### `{inputMapper}.zoomOut(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to zoom out on the current web page
+using buttons and triggers.
+
+### `{inputMapper}.thumbstickZoom(value, invert)`
+
+- `value {Number}` Current value of the gamepad input.
+- `invert {Boolean}` Whether the thumbstick direction for zoom should be in opposite order (see below).
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to change the zoom on the current
+web page according to the direction the thumbstick is pressed. For example, left on the horizontal axis and upward on
+the vertical axis of a thumbstick should zoom in on the current web page. Pressing the thumbstick in opposite direction
+should zoom out on the current web page.
+
+### `{inputMapper}.maximizeWindow(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to maximize the current browser
+window using buttons and triggers.
+
+### `{inputMapper}.restoreWindowSize(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to restore the size of current
+browser window using buttons and triggers.
+
+### `{inputMapper}.thumbstickWindowSize(value, invert)`
+
+- `value {Number}` Current value of the gamepad input.
+- `invert {Boolean}` Whether the thumbstick direction for zoom should be in opposite order (see below).
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to change the size of current
+browser window according to the direction the thumbstick is pressed. For example, left on the horizontal axis and upward
+on the vertical axis of a thumbstick should restore the current browser window size. Pressing the thumbstick in opposite
+direction should maximize the current browser window.
+
+### `{inputMapper}.reopenTabOrWindow(value, oldValue)`
+
+- `value {Number}` Current value of the gamepad input.
+- `oldValue {Number}` Previous value of the gamepad input.
+- Returns: Nothing.
+
+Sends a message to the `messageListener` component present in the background script to reopen the last closed browser
+session using buttons and triggers. The closed session could be a tab or a window.

--- a/docs/components/inputMapper.md
+++ b/docs/components/inputMapper.md
@@ -68,7 +68,8 @@ or after the web page is reloaded due to refreshing or history navigation.
 
 - Returns: Nothing.
 
-Updates the gamepad configuration saved by the user.
+Listens to the `onCreate` event of the `inputMapper` component and updates the `map` model variable with the custom
+gamepad configuration data (saved using the configuration panel).
 
 ## Navigation Invokers
 
@@ -201,7 +202,7 @@ browser window using buttons and triggers.
 - `invert {Boolean}` Whether the thumbstick direction for zoom should be in opposite order (see below).
 - Returns: Nothing.
 
-Sends a message to the `messageListener` component present in the background script to change the size of current
+Sends a message to the `messageListener` component present in the background script to change the size of the current
 browser window according to the direction the thumbstick is pressed. For example, left on the horizontal axis and upward
 on the vertical axis of a thumbstick should restore the current browser window size. Pressing the thumbstick in opposite
 direction should maximize the current browser window.

--- a/src/js/content_scripts/input-mapper.js
+++ b/src/js/content_scripts/input-mapper.js
@@ -98,7 +98,8 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
     /**
      *
-     * Restore the previously focused element on the webpage after history navigation.
+     * Restore the previously focused element on the web page after history navigation or
+     * switching tabs/windows.
      *
      * @param {Object} windowObject - The inputMapper component's windowObject option.
      * @param {Function} tabindexSortFilter - The filter to be used for sorting elements
@@ -136,12 +137,16 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
      *
      * @param {Function} inputMapperManager - The function that handles the instance of
      *                                        the inputMapper component.
+     * @param {Object} configurationOptions - The configuration options for the
+     *                                        inputMapper component.
      *
      */
     gamepad.visibilityChangeTracker = (function (windowObject) {
         // Assume that the page isn't focused initially.
         var inView = false;
-        return function (inputMapperManager) {
+        return function (inputMapperManager, configurationOptions) {
+            configurationOptions = configurationOptions || {};
+
             // Track changes to the focus/visibility of the window object.
             windowObject.onfocus = windowObject.onblur = windowObject.onpageshow = windowObject.onpagehide = function (event) {
                 /**
@@ -155,7 +160,7 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
                      * (using inView to verify).
                      */
                     if (!inView) {
-                        inputMapperManager("visible");
+                        inputMapperManager("visible", configurationOptions);
                         inView = true;
                     }
                 }
@@ -178,19 +183,23 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
      * tab/window.
      *
      * @param {String} visibilityStatus - The visibility status of the tab/window.
+     * @param {Object} configurationOptions - The configuration options for the
+     *                                        inputMapper component.
      *
      */
     gamepad.inputMapperManager = (function () {
         var inputMapperInstance = null;
 
-        return function (visibilityStatus) {
+        return function (visibilityStatus, configurationOptions) {
+            configurationOptions = configurationOptions || {};
+
             /**
              * Create an instance of the inputMapper when the tab/window is focused
              * again and start reading gamepad inputs (if any gamepad is connected).
              */
             if (visibilityStatus === "visible") {
-                // Obtain the saved configuration of the gamepad.
-                inputMapperInstance = gamepad.inputMapper();
+                // Pass the configuration options to the inputMapper component.
+                inputMapperInstance = gamepad.inputMapper(configurationOptions);
                 inputMapperInstance.events.onGamepadConnected.fire();
             }
             else if (visibilityStatus === "hidden" && inputMapperInstance !== null) {

--- a/src/js/content_scripts/input-mapper.js
+++ b/src/js/content_scripts/input-mapper.js
@@ -198,6 +198,11 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
              * again and start reading gamepad inputs (if any gamepad is connected).
              */
             if (visibilityStatus === "visible") {
+                /**
+                 * TODO: Refactor the approach to use a dynamic component instead of
+                 * creating components dynamically.
+                 */
+
                 // Pass the configuration options to the inputMapper component.
                 inputMapperInstance = gamepad.inputMapper(configurationOptions);
                 inputMapperInstance.events.onGamepadConnected.fire();


### PR DESCRIPTION
While writing the `inputMapper` component's documentation, I realized that we are not providing any means to pass in custom configuration options to the component, given how it's handled for multiple tabs and windows. This pull request also addresses that issue.