### PR TITLE
NOGH: Removed multiple "tabs" from the permissions array

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,8 +7,7 @@
     "permissions": [
         "storage",
         "tabs",
-        "sessions",
-        "tabs"
+        "sessions"
     ],
     "content_scripts": [
         {


### PR DESCRIPTION
The manifest file had multiple "tabs" entries in the permissions array. Those extra entries were removed in this pull request.