### PR TITLE
NOGH: Corrected the version in manifest.json and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gamepad-navigator",
-    "version": "0.1.0",
+    "version": "0.1.0-dev",
     "description": "The Gamepad Navigator is a configurable application that allows you to navigate web pages and browsers using a game controller.",
     "author": "Divyanshu Mahajan",
     "license": "BSD-3-Clause",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Gamepad Navigator",
-    "version": "0.1.0",
+    "version": "0.1.0-dev",
     "description": "The Gamepad Navigator is a Chrome extension that allows you to navigate web pages and Chromium-based browsers using a game controller.",
     "author": "Divyanshu Mahajan",
     "manifest_version": 2,


### PR DESCRIPTION
While preparing the extension for publication to the Chrome Web Store, I noticed the version numbers in the manifest.json and package.json files in the repository were not updated (though it was correct in the zip attached with the release [v0.1.0-dev](https://github.com/fluid-lab/gamepad-navigator/releases/tag/v0.1.0-dev)). This pull request rectifies the version number.