### PR TITLE
NOGH: Updated gpii-grunt-lint-all to fluid-grunt-lint-all

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -343,7 +343,7 @@ module.exports = function (grunt) {
         };
     });
 
-    grunt.loadNpmTasks("gpii-grunt-lint-all");
+    grunt.loadNpmTasks("fluid-grunt-lint-all");
     grunt.loadNpmTasks("grunt-banner");
     grunt.loadNpmTasks("grunt-contrib-clean");
     grunt.loadNpmTasks("grunt-contrib-copy");

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "dotenv": "8.2.0",
         "eslint": "7.1.0",
         "eslint-config-fluid": "1.4.0",
-        "gpii-grunt-lint-all": "1.0.7",
+        "fluid-grunt-lint-all": "1.0.8",
         "grunt": "1.1.0",
         "grunt-banner": "0.6.0",
         "grunt-contrib-clean": "2.0.0",


### PR DESCRIPTION
Updated the package `gpii-grunt-lint-all` (v1.0.7) to [`fluid-grunt-lint-all`](https://www.npmjs.com/package/fluid-grunt-lint-all) (v1.0.8).