### PR TITLE
NOGH: Changed the version update mechanism as per Chrome extension's versioning norms

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,9 @@ module.exports = function (grunt) {
         clean: {
             previousBuild: {
                 src: ["dist/"]
+            },
+            zip: {
+                src: ["*.zip"]
             }
         },
         copy: {
@@ -81,7 +84,7 @@ module.exports = function (grunt) {
                 dest: "dist/"
             }
         },
-        manifest: grunt.file.readJSON("src/manifest.json"),
+        packageJSON: grunt.file.readJSON("package.json"),
         updateVersion: {
             options: { jsonFiles: ["package.json", "src/manifest.json"] }
         },
@@ -91,7 +94,7 @@ module.exports = function (grunt) {
         },
         compress: {
             dist: {
-                options: { archive: "build_v<%= grunt.file.readJSON(\"src/manifest.json\").version %>.zip" },
+                options: { archive: "build_v<%= packageJSON.version %>.zip" },
                 files: [{
                     expand: true,
                     cwd: "dist/",
@@ -105,12 +108,12 @@ module.exports = function (grunt) {
                     questions: [{
                         config: "githubRelease.options.tag_name",
                         type: "input",
-                        default: "v<%= manifest.version %>",
+                        default: "v<%= packageJSON.version %>",
                         message: "Tag version:"
                     }, {
                         config: "githubRelease.options.name",
                         type: "input",
-                        default: "v<%= manifest.version %>",
+                        default: "v<%= packageJSON.version %>",
                         message: "Release title:"
                     }, {
                         config: "githubRelease.options.body",
@@ -133,7 +136,7 @@ module.exports = function (grunt) {
         githubRelease: {
             options: {
                 repo: "fluid-lab/gamepad-navigator",
-                asset: "build_v<%= manifest.version %>.zip"
+                asset: "build_v<%= packageJSON.version %>.zip"
             }
         }
     });
@@ -182,7 +185,7 @@ module.exports = function (grunt) {
 
             var newVersionNumber = versionSpecs.join(".").toString(),
                 newVersion = newVersionNumber;
-            if (!isStandard) {
+            if (!isStandard && path.basename(jsonFile) !== "manifest.json") {
                 newVersion = newVersion + "-dev";
             }
 
@@ -353,6 +356,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask("lint", "Perform all standard lint checks.", ["lint-all"]);
     grunt.registerTask("banner", "Add copyright banner at the top of files.", ["usebanner"]);
+
     grunt.registerTask("build", "Build an unpacked extension.", ["clean", "copy"]);
     grunt.registerTask("archive", "Generate an zip package of the extension.", ["build", "compress"]);
     grunt.registerTask("release", "Create a new release on GitHub and upload the extension's zip file.", ["archive", "prompt", "githubRelease"]);

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ You can check out the recorded demo to see how the navigator works.
    </a>
 </p>
 
+## Contributing
+
+See [CONTRIBUTING](CONTRIBUTING.md) for detailed information.
+
 ## Publishing
 
 For the steps to publish the extension to the Chrome Web Store, please refer to the [PUBLISHING](docs/PUBLISHING.md)

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -14,9 +14,12 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
 
 1. Prepare the code and the `master` branch.
    1. Update the `version` number in the [manifest](src/manifest.json#L3) and [package](package.json#L3) files.
-      1. The project follows semantic versioning, i.e. the version is in the format "{MAJOR.MINOR.PATCH}[-dev]". For
-         example, 1.0.15 and 1.1.9-dev.  
-         (Refer to the [semantic versioning](https://semver.org/) standard documentation for more details)
+      1. The project follows [semantic versioning](https://semver.org/), i.e. the version is in the format
+         "{MAJOR.MINOR.PATCH}[-dev]". For example, "1.0.15" and "1.1.9-dev".
+         1. The `version` number in [manifest.json](src/manifest.json) file should be completely numeric. However, other
+            json files (for example, [package.json](package.json)) may contain alphabets and non-numeric characters with
+            the version number.  
+            (See [Manifest Version](https://developer.chrome.com/extensions/manifest/version) for more details)
       2. If the release is a **dev release**, use one of the following commands.
          1. For bug fixes with no API or functionality changes, update the PATCH version: `grunt updateVersion --patch`
          2. For minor API changes and functionality updates, update the MINOR version: `grunt updateVersion --minor`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gamepad-navigator",
-    "version": "0.1.0-dev",
+    "version": "0.1.1-dev",
     "description": "The Gamepad Navigator is a configurable application that allows you to navigate web pages and browsers using a game controller.",
     "author": "Divyanshu Mahajan",
     "license": "BSD-3-Clause",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Gamepad Navigator",
-    "version": "0.1.0-dev",
+    "version": "0.1.1",
     "description": "The Gamepad Navigator is a Chrome extension that allows you to navigate web pages and Chromium-based browsers using a game controller.",
     "author": "Divyanshu Mahajan",
     "manifest_version": 2,


### PR DESCRIPTION
The new update mechanism would increment the version number in both `package.json` and `manifest.json` files, but the "dev" part or the substring would only be visible in `package.json` file (or any JSON file other than `manifest.json`). This pull also updates the version to `v0.1.1-dev`. The new release would be created after this pull request gets merged.