### PR TITLE
NOGH: Reduced description in the package.json and manifest.json within 132 characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "gamepad-navigator",
     "version": "0.1.1-dev",
-    "description": "The Gamepad Navigator is a configurable application that allows you to navigate web pages and browsers using a game controller.",
+    "description": "A Chrome extension that allows you to navigate web pages and Chromium-based browsers using a game controller.",
     "author": "Divyanshu Mahajan",
     "license": "BSD-3-Clause",
     "repository": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Gamepad Navigator",
     "version": "0.1.1",
-    "description": "The Gamepad Navigator is a Chrome extension that allows you to navigate web pages and Chromium-based browsers using a game controller.",
+    "description": "A Chrome extension that allows you to navigate web pages and Chromium-based browsers using a game controller.",
     "author": "Divyanshu Mahajan",
     "manifest_version": 2,
     "permissions": [


### PR DESCRIPTION
This pull request reduces the characters in the description of the `manifest.json` and `package.json` within the 132 character limit, as required for publishing to the Chrome Web Store. 