### PR TITLE
NOGH: Added Chrome Web Store link and configuration panel keyboard shortcut to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ reconfigured from the application to redefine what each d-pad, thumbstick, butto
 
 ## Installation
 
+The Gamepad Navigator Chrome Extension is available for free on the
+[Chrome Web Store](https://chrome.google.com/webstore/detail/gamepad-navigator/egilmijcknfacjjbchcacijkknbkgfnd).
+
+[![Chrome Web Store](https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png)](https://chrome.google.com/webstore/detail/gamepad-navigator/egilmijcknfacjjbchcacijkknbkgfnd)
+
+The extension can also be installed on other Chromium-based browsers using the source code.  
+(Refer to the steps mentioned below)
+
 1. Clone or download the repository.
 
 2. Install [grunt-cli](https://gruntjs.com/) globally:
@@ -137,7 +145,8 @@ The default action for each gamepad input is as follows.
 | `Right Thumbstick Horizontal Direction` | History navigation | - | `false` |
 | `Right Thumbstick Vertical Direction` | Focus on the previous/next element | `2.5` | `false` |
 
-<!-- TODO: Mention the keyboard shortcut to open the configuration panel. -->
+The configuration panel can be opened by clicking on the Gamepad Navigator pop-up icon. You can also use the keyboard
+shortcut `Ctrl + Shift + 5` to open the configuration panel.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ The Gamepad Navigator Chrome Extension is available for free on the
 
 [![Chrome Web Store](https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png)](https://chrome.google.com/webstore/detail/gamepad-navigator/egilmijcknfacjjbchcacijkknbkgfnd)
 
-The extension can also be installed on other Chromium-based browsers using the source code.  
-(Refer to the steps mentioned below)
+The extension can also be installed on other Chromium-based browsers using the source code (see below).
 
 1. Clone or download the repository.
 
@@ -146,7 +145,7 @@ The default action for each gamepad input is as follows.
 | `Right Thumbstick Vertical Direction` | Focus on the previous/next element | `2.5` | `false` |
 
 The configuration panel can be opened by clicking on the Gamepad Navigator pop-up icon. You can also use the keyboard
-shortcut `Ctrl + Shift + 5` to open the configuration panel.
+shortcut `Alt + Shift + G` to open the configuration panel.
 
 ## Demo
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -48,7 +48,7 @@
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {
-                "default": "Ctrl+Shift+5"
+                "default": "Alt+Shift+G"
             }
         }
     }


### PR DESCRIPTION
As the Gamepad Navigator has been released earlier on the Chrome Web Store, I think it should be good to add a reference to the Web Store listing somewhere in the README. This pull request adds a Web Store badge referring to the extension on the store. Along with that, the pull request also adds the keyboard shortcut (for opening the configuration panel) to the README.