### PR TITLE
GH-81: Migrate to `fluid-lint-all`, fix linting errors, adjust rules (resolves #81).

### DIFF
--- a/.fluidlintallrc.json
+++ b/.fluidlintallrc.json
@@ -1,0 +1,19 @@
+{
+    "sources": {
+        "js":    ["./src/js/**/*.js", "tests/js/**/*.js", "./*.js"],
+        "md":    ["./*.md", "tests/**/*.md", "docs/**/*.md"],
+        "json":  ["./*.json", "./.*.json", "tests/**/*.json"],
+        "json5": ["./*.json5", "tests/**/*.json5"],
+        "other": ["./.*"]
+    },
+    "lintspaces": {
+        "newlines": {
+            "excludes": ["./node_modules/**/*", "./src/images/**/*", "./src/fonts/**/*"]
+        }
+    },
+    "stylelint": {
+        "options": {
+            "configFile": ".stylelintrc.json"
+        }
+    }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm install
 
       - name: Lint Code
-        run: $(npm bin)/grunt lint
+        run: npm run lint
 
       - name: Node Tests
         run: xvfb-run --auto-servernum npm test

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "stylelint-config-fluid",
+    "rules": {
+        "selector-list-comma-newline-after": "always-multi-line"
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ confident in our ability to avoid regressions. All unit tests should be written 
 
 JavaScript is a highly dynamic and loose language, and many common errors are not picked up until runtime. To avoid
 errors and common pitfalls in the language, and to maintain consistency in terms of syntax, lint your code regularly
-using the provided Grunt lint task (see below). Ensure that you run lint checks on your code before making a commit.
+using the provided npm script (see below). Ensure that you run lint checks on your code before making a commit.
 
 ``` snippet
 # Runs linting tasks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ using the provided Grunt lint task (see below). Ensure that you run lint checks 
 
 ``` snippet
 # Runs linting tasks
-grunt lint
+npm run lint
 ```
 
 ### Create Meaningful Commit Logs

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,15 +22,6 @@ var path = require("path"),
 
 module.exports = function (grunt) {
     grunt.config.init({
-        lintAll: {
-            sources: {
-                js:    ["./src/js/**/*.js", "tests/js/**/*.js", "./*.js"],
-                md:    ["./*.md", "tests/**/*.md", "docs/**/*.md"],
-                json:  ["./*.json", "./.*.json", "tests/**/*.json"],
-                json5: ["./*.json5", "tests/**/*.json5"],
-                other: ["./.*"]
-            }
-        },
         usebanner: {
             options: {
                 licenseBanner: grunt.file.read("templates/LICENSE-banner.txt"),
@@ -346,7 +337,6 @@ module.exports = function (grunt) {
         };
     });
 
-    grunt.loadNpmTasks("fluid-grunt-lint-all");
     grunt.loadNpmTasks("grunt-banner");
     grunt.loadNpmTasks("grunt-contrib-clean");
     grunt.loadNpmTasks("grunt-contrib-copy");
@@ -354,12 +344,11 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-prompt");
     grunt.loadNpmTasks("grunt-json-prettify");
 
-    grunt.registerTask("lint", "Perform all standard lint checks.", ["lint-all"]);
     grunt.registerTask("banner", "Add copyright banner at the top of files.", ["usebanner"]);
 
     grunt.registerTask("build", "Build an unpacked extension.", ["clean", "copy"]);
     grunt.registerTask("archive", "Generate an zip package of the extension.", ["build", "compress"]);
     grunt.registerTask("release", "Create a new release on GitHub and upload the extension's zip file.", ["archive", "prompt", "githubRelease"]);
 
-    grunt.registerTask("default", ["lint", "banner", "build"]);
+    grunt.registerTask("default", ["banner", "build"]);
 };

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -33,7 +33,7 @@ https://github.com/fluid-lab/gamepad-navigator/blob/master/LICENSE
       5. Push the changes to the `master` branch.
    2. Ensure that all of the code that should be published has been merged into the `master` branch.
    3. Ensure that the code in the `master` branch is working as expected.
-      1. Lint: `grunt lint`
+      1. Lint: `npm run lint`
       2. Run tests: `npm test`
       3. Manual test build.
          1. Create a build and load the generated unpacked extension into Chrome.  

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "dotenv": "8.2.0",
         "eslint": "7.17.0",
         "eslint-config-fluid": "2.0.0",
-        "fluid-lint-all": "1.0.0-dev.20210113T154306Z.b842b2c.GH-1",
+        "fluid-lint-all": "1.0.0",
         "grunt": "1.3.0",
         "grunt-banner": "0.6.0",
         "grunt-contrib-clean": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,27 +13,27 @@
     },
     "homepage": "https://github.com/fluid-lab/gamepad-navigator#readme",
     "scripts": {
-        "lint": "grunt lint",
+        "lint": "fluid-lint-all",
         "postinstall": "grunt build",
         "test": "testem ci --file tests/testem.json"
     },
     "dependencies": {
         "ally.js": "1.4.1",
-        "infusion": "3.0.0-dev.20200326T173810Z.24ddb2718"
+        "infusion": "3.0.0-dev.20201113T153152Z.32176dcbe.FLUID-6145"
     },
     "devDependencies": {
         "dotenv": "8.2.0",
-        "eslint": "7.1.0",
-        "eslint-config-fluid": "1.4.0",
-        "fluid-grunt-lint-all": "1.0.8",
-        "grunt": "1.1.0",
+        "eslint": "7.17.0",
+        "eslint-config-fluid": "2.0.0",
+        "fluid-lint-all": "1.0.0-dev.20210113T154306Z.b842b2c.GH-1",
+        "grunt": "1.3.0",
         "grunt-banner": "0.6.0",
         "grunt-contrib-clean": "2.0.0",
-        "grunt-contrib-compress": "1.6.0",
+        "grunt-contrib-compress": "2.0.0",
         "grunt-contrib-copy": "1.0.0",
         "grunt-json-prettify": "0.0.2",
         "grunt-prompt": "1.3.3",
-        "node-fetch": "2.6.0",
+        "node-fetch": "2.6.1",
         "testem": "3.2.0"
     }
 }

--- a/src/css/configuration-panel.css
+++ b/src/css/configuration-panel.css
@@ -1,10 +1,10 @@
 @font-face {
-    font-family: ubuntu;
+    font-family: ubuntu, sans-serif;
     src: url("../fonts/Ubuntu-Medium.ttf");
 }
 
 * {
-    font-family: ubuntu;
+    font-family: ubuntu, sans-serif;
 }
 
 :root {
@@ -12,32 +12,32 @@
 }
 
 .gamepad-controls {
-    width: var(--width);
-    height: 228px;
     background-image: url("../images/gamepad.svg");
     background-position: center;
     background-repeat: no-repeat;
     background-size: contain;
+    height: 228px;
+    width: var(--width);
 }
 
 .input-list-label {
-    margin-left: 15px;
     margin-bottom: 15px;
+    margin-left: 15px;
 }
 
 .input-list {
-    width: 93.5%;
     margin: 10px 15px 0;
+    width: 93.5%;
 }
 
 .configuration-menu {
     display: grid;
     grid-auto-flow: column;
     grid-template-columns: repeat(20, var(--width));
-    width: var(--width);
-    overflow-x: scroll;
     margin-bottom: 10px;
+    overflow-x: scroll;
     overflow-y: hidden;
+    width: var(--width);
 }
 
 .configuration-menu::-webkit-scrollbar {
@@ -45,30 +45,30 @@
 }
 
 .menu-item {
-    padding: 0 15px;
-    height: 125px;
-    width: calc(var(--width) - 30px);
     display: grid;
     grid-auto-flow: column;
     grid-template-columns: 2fr 1fr;
     grid-template-rows: 1fr 1fr 3fr 2fr;
+    height: 125px;
+    padding: 0 15px;
+    width: calc(var(--width) - 30px);
 }
 
 .action-label {
-    grid-row: 2/3;
     grid-column: 1/2;
+    grid-row: 2/3;
 }
 
 label {
-    margin-top: 3px;
     font-size: 1.05rem;
+    margin-top: 3px;
 }
 
-select, input {
-    margin: 10px 20px 10px 0;
-    padding: 10px 5px;
+select,input {
     border: 2px solid;
     font-size: 1rem;
+    margin: 10px 20px 10px 0;
+    padding: 10px 5px;
 }
 
 input {
@@ -76,9 +76,9 @@ input {
 }
 
 select {
-    width: 100%;
     grid-column: 1/3;
     grid-row: 3/4;
+    width: 100%;
 }
 
 select:focus, input:focus {
@@ -86,8 +86,8 @@ select:focus, input:focus {
 }
 
 .speed-factor {
-    grid-row: 3/4;
     background-color: #ddd;
+    grid-row: 3/4;
 }
 
 .speed-factor, .speed-factor-label {
@@ -101,18 +101,18 @@ select:focus, input:focus {
 .checkbox-label {
     grid-column: 1/3;
     grid-row: 4/5;
-    margin-top: 4px;
     margin-left: 25px;
+    margin-top: 4px;
 }
 
 .checkbox {
-    transform: scale(1.3);
+    align-self: center;
     grid-column: 1/2;
     grid-row: 4/5;
-    align-self: center;
     justify-self: start;
-    width: auto;
     margin: 2px 37px 0 2px;
+    transform: scale(1.3);
+    width: auto;
 }
 
 select, .speed-factor, .checkbox {
@@ -120,23 +120,23 @@ select, .speed-factor, .checkbox {
 }
 
 .buttons-container {
-    width: var(--width);
-    padding: 5px 15px 15px;
-    display: grid;
-    grid-template-rows: 1fr 1fr;
-    grid-template-columns: 1fr 1fr;
-    gap: 10px;
     box-sizing: border-box;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    padding: 5px 15px 15px;
+    width: var(--width);
 }
 
 .button {
     color: white;
-    font-weight: 550;
-    font-size: 1rem;
-    height: 50px;
-    width: auto;
-    padding: 0px 22px;
     cursor: pointer;
+    font-size: 1rem;
+    font-weight: 550;
+    height: 50px;
+    padding: 0 22px;
+    width: auto;
 }
 
 .button:focus, .button:hover {
@@ -152,11 +152,11 @@ select, .speed-factor, .checkbox {
 }
 
 .button:nth-child(2) {
-    background-color: #1169CB;
+    background-color: #1169cb;
 }
 
 .button:focus:nth-child(2), .button:hover:nth-child(2) {
-    background-color: #4169EF;
+    background-color: #4169ef;
 }
 
 .button:nth-child(3) {
@@ -183,8 +183,8 @@ select, .speed-factor, .checkbox {
 }
 
 .reduced {
-    width: 96.5%;
     grid-column: 1/2;
+    width: 96.5%;
 }
 
 .hidden {
@@ -194,8 +194,8 @@ select, .speed-factor, .checkbox {
 /* Dark Mode Stylesheet */
 @media (prefers-color-scheme: dark) {
     body {
-        color: #e96c4c;
         background-color: #141e24;
+        color: #e96c4c;
     }
 
     .gamepad-controls {
@@ -203,9 +203,9 @@ select, .speed-factor, .checkbox {
     }
 
     select, .speed-factor, .checkbox {
-        background-color: #1B697B;
+        background-color: #1b697b;
+        border-color: #1b697b;
         color: white;
-        border-color: #1B697B;
     }
 
     .button {
@@ -213,35 +213,35 @@ select, .speed-factor, .checkbox {
     }
 
     .button:nth-child(1) {
-        background-color: #EAAD3F;
+        background-color: #eaad3f;
     }
 
     .button:focus:nth-child(1), .button:hover:nth-child(1) {
-        background-color: #FFB235;
+        background-color: #ffb235;
     }
 
     .button:nth-child(2) {
-        background-color: #2D7BAE;
+        background-color: #2d7bae;
     }
 
     .button:focus:nth-child(2), .button:hover:nth-child(2) {
-        background-color: #2A7FCA;
+        background-color: #2a7fca;
     }
 
     .button:nth-child(3) {
-        background-color: #E96C65;
+        background-color: #e96c65;
     }
 
     .button:focus:nth-child(3), .button:hover:nth-child(3) {
-        background-color: #FF5D54;
+        background-color: #ff5d54;
     }
 
     .button:nth-child(4) {
-        background-color: #A0CC68;
+        background-color: #a0cc68;
     }
-    
+
     .button:focus:nth-child(4), .button:hover:nth-child(4) {
-        background-color: #97CF52;
+        background-color: #97cf52;
     }
 
     .button:disabled:nth-child(3),


### PR DESCRIPTION
Although we use `Grunt` for other things in this package, moving forward the linting infrastructure used within the community is migrating away from `Grunt`.  This pull migrates this package to use the new tool, and fixing the minor linting errors that result from the new CSS linting added in recent versions.

@dmahajan980, this should be merged once there is a full release, but I've flagged it for your review in the mean time.